### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 An NFS server for JupyterHub that runs within your Kubernetes cluster to provide persistent storage for users and enforce storage quotas.
 
 ## Key Components
-- [NFS Ganesha](https://https://github.com/nfs-ganesha/nfs-ganesha) is used as the NFS server
+- [NFS Ganesha](https://github.com/nfs-ganesha/nfs-ganesha) is used as the NFS server
 - [XFS](https://xfs.org/) as the filesystem
 - [xfs_quota](https://man7.org/linux/man-pages/man8/xfs_quota.8.html) through [get-quota-your-home](https://github.com/yuvipanda/get-quota-your-home) is used to manage storage quotas


### PR DESCRIPTION
There was a duplicate `https://` in the NFS Ganesha link.

I don't know what changed on line 8, however. I did it in the GitHub editor, and I don't see a difference... 